### PR TITLE
Fix parameter passing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   - path: rabbitmq-script-wrapper  # wrapper to fake RABBITMQ_HOME location
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   no_link:
     - etc/rabbitmq

--- a/recipe/rabbitmq-script-wrapper
+++ b/recipe/rabbitmq-script-wrapper
@@ -15,15 +15,15 @@
 ##  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 ##
 
-cd ${PREFIX}/var/lib/rabbitmq
+cd "${PREFIX}/var/lib/rabbitmq"
 
 SCRIPT=`basename $0`
 
 if [ "$SCRIPT" = "rabbitmq-server" ] ; then
-    exec ${PREFIX}/lib/rabbitmq/sbin/rabbitmq-server $*
+    exec "${PREFIX}/lib/rabbitmq/sbin/rabbitmq-server" "$@"
 else
     if [ -f $PWD/.erlang.cookie ] ; then
         export HOME=.
     fi
-    exec ${PREFIX}/lib/rabbitmq/sbin/${SCRIPT} $*
+    exec "${PREFIX}/lib/rabbitmq/sbin/${SCRIPT}" "$@"
 fi


### PR DESCRIPTION
`$*` will run parameters through globbing, so the string `.*` will
become a list of filenames. This means
```
rabbitmqctl set_permissions -p / admin '.*' '.*' '.*'
```
could be turned into
```
$PREFIX/rabbitmqctl set_permissions -p / admin . .. .mkdir . .. .mkdir . .. .mkdir
```

`"$*"` would pass all parameters as a single string, which also doesn't
work. Instead use `$@`, which passes the parameters as a list, and
specifically `"$@"`, whichhttps://github.com/conda-forge/rabbitmq-server-feedstock/pull/31/commits passes the parameters as a list without
applying any expansions.

I also added `""` around the exec paths, which might fix issues with spaces in the prefix. I haven't tested if that is an actual issue, but figured that adding them doesn't come with an extra cost.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
